### PR TITLE
Allow setting api routes middleware in the config file

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -8,9 +8,7 @@ use Code16\Formoj\Controllers\FormojUploadController;
 
 Route::group([
     'prefix' => config("formoj.base_url"),
-    'middleware' => [
-        \Illuminate\Routing\Middleware\SubstituteBindings::class
-    ],
+    'middleware' => config("formoj.api_middleware"),
 ], function() {
     Route::get('/form/{form}', [FormojFormController::class, 'show']);
     Route::post('/form/{form}/validate/{section}', [FormojSectionController::class, 'update']);

--- a/src/config.php
+++ b/src/config.php
@@ -8,6 +8,13 @@ return [
     "base_url" => "/formoj/api/",
 
     /**
+     * API middleware
+     */
+    "api_middleware" => [
+        \Illuminate\Routing\Middleware\SubstituteBindings::class
+    ],
+
+    /**
      * Disk and base path used for export XLS storage.
      */
     "export" => [


### PR DESCRIPTION
Hello,

I'm using this great package for a multi-tenant application and I need to be able to set custom middleware for the api routes.

I made it so the middleware array is configurable in formoj.php.

Thank you.
